### PR TITLE
feat: More suitable for Academic users from Github theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 !.assets/**
 !novel-tex/
 !novel-tex/**
+!academic-tex-l.css
 !novel-tex-f-d.css
 !novel-tex-n-d.css
 !novel-tex-f-l.css

--- a/academic-tex-l.css
+++ b/academic-tex-l.css
@@ -1,0 +1,20 @@
+@charset "UTF-8";
+@import "./novel-tex/light/basic-light-config-academic.css";
+@import "./novel-tex/light/code-light-academic.css";
+
+:root {
+  /*
+  目录树颜色
+  */
+  --active-file-bg-color: rgb(240, 240, 240);
+  --active-file-text-color: var(--text-color);
+
+  /*
+  界面UI的字体颜色
+  */
+  --item-hover-bg-color: var(--active-file-bg-color);
+  --item-hover-text-color: var(--active-file-text-color);
+
+  --code-bg-color: rgb(250, 250, 250);
+  --sidebar-bg-color: rgb(250, 250, 250);
+}

--- a/novel-tex/basic/base-config-academic.css
+++ b/novel-tex/basic/base-config-academic.css
@@ -1,0 +1,245 @@
+@import "./basic-mermaid.css";
+@import "./math.css";
+/* @import "./md-toc.css"; */
+@import "./table.css";
+@import "./ui.css";
+
+:root {
+    /* == 使用页面设置 == */
+    /* 页面边距 */
+    --base-page-margin: 45px;
+
+
+    /* == 基础字体设置 == */
+    --base-Latin-font: "Times New Roman";
+    --base-Chinese-font: "Source Han Serif SC";
+    --base-font-size: 1.15em;
+
+    /* 引言字体设置 */
+    --quote-font: "Source Han Serif SC";
+    --quote-font-size: 0.95em;
+
+    /* 源代码模式字体设置 */
+    --sourceMode-font: var(--base-Latin-font), var(--base-Chinese-font);
+
+    /* 表格字体（默认调用 heading-font） */
+    --table-title-font: "";
+    --table-font: "";
+
+    /* 标题字体（总设置）*/
+    --heading-Latin-font: var(--base-Latin-font);
+    --heading-Chinese-font: var(--base-Chinese-font);
+    --h1-Chinese-font: var(--base-Chinese-font);
+    --h1-font-size: 1.9em;
+    --h2-Chinese-font: var(--base-Chinese-font);
+    --h2-font-size: 1.5em;
+    --h3-Chinese-font: var(--base-Chinese-font);
+    --h3-font-size: 1.25em;
+    --h4-Chinese-font: var(--base-Chinese-font);
+    --h4-font-size: 1.15em;
+    --h5-Chinese-font: var(--base-Chinese-font);
+    --h5-font-size: 1.10em;
+    --h6-Chinese-font: var(--base-Chinese-font);
+    --h6-font-size: 1.10em;
+
+    /* 粗体样式设置（normal: 400，bold: 700，heavy: 900） */
+    --strong-weight: 900;
+    /* 基础行距 */
+    --base-line-height: 1.618em;
+    /* 打印页边距 */
+    --set-margin: 1.8cm 2cm 1.8cm 2cm !important;
+    /* 目录中是否显示一级标题 */
+    --toc-show-title: none;
+    /*普通文本颜色*/
+    --text-color: rgb(180, 180, 180);
+    --title-text-color: rgb(240, 240, 240); 
+    --strong-text-color: var(--text-color);
+
+    /*目录文本颜色*/
+    --toc-font-color: var(--text-color);
+    /*代码字体颜色*/
+    --code-font-color: var(--text-color);
+
+    /* 超链接颜色 */
+    --link-color: #7E8B92;
+
+    /*改变元字符的颜色，例如 markdown 中的“*”*/
+    --md-char-color: #C7C5C5;
+    /*改变元内容的颜色，例如 markdown 中的图像文本和链接地址*/
+    --meta-content-color: #5b808d;
+}
+
+body {
+    padding: 0 !important;
+    margin: 0 !important;
+}
+
+img {
+    page-break-inside: avoid;
+    /* 避免图片在导出时被断开 */
+}
+
+/* strong {
+    font-weight: var(--strong-weight) !important;
+    color: var(--strong-text-color);
+} */
+
+@media screen {
+    #write {
+        padding: var(--set-margin);
+        border: 1px solid var(--body-border-color);
+    }
+}
+
+pre.md-meta-block {
+    /* 元数据（如 YAML front matter）的背景框 */
+    background: var(--bg-color);
+    padding: 1.4em;
+    font-family: var(--code-font), var(--ui-font), monospace;
+    font-size: 0.8em;
+}
+
+#write {
+    counter-reset: h2 0 h3 0 h4 0 h5 0 h6 0;
+}
+
+#write {
+    font-family: var(--base-Latin-font), var(--base-Chinese-font), serif;
+    font-size: var(--base-font-size);
+    max-width: 26cm;
+    background-color: var(--bg-color);
+
+    /* github */
+    /* max-width: 860px; */
+    margin: 0 auto;
+        /* 页边距 */
+    padding: var(--base-page-margin);
+    padding-bottom: 100px;
+}
+
+strong,
+#write strong{
+    font-weight: var(--strong-weight);
+    color: var(--strong-text-color);
+    font-family: var(--base-Latin-font), var(--base-Chinese-font), serif;
+
+    /* 字体不支持加粗，阴影模拟加粗 */
+    text-shadow: 0.05px 0 0 #000, 0 0.05px 0 #000, -0.05px 0 0 #000, 0 -0.05px 0 #000;
+}
+
+
+#write .md-math-block,
+#write .md-rawblock,
+#write p {
+    text-align: justify;
+    line-height: var(--base-line-height);
+    margin-top: 1em;
+    margin-bottom: 1em;
+
+    /* 使用下面的全部颜色会锁定,包括引言 */
+    /* color: var(--text-color); */
+}
+
+#write a {
+    color: var(--link-color);
+}
+
+
+#write h1,
+#write h2,
+#write h3,
+#write h4,
+#write h5,
+#write h6 {
+    font-weight: bold;
+    page-break-after: avoid !important;
+    color: var(--title-text-color);
+}
+
+#write h1 {
+    font-family: var(--heading-Latin-font), var(--h1-Chinese-font), serif;
+    text-align: center;
+    column-span: all;
+    font-size: var(--h1-font-size);
+}
+
+#write h2 {
+    font-family: var(--heading-Latin-font), var(--h2-Chinese-font), serif;
+    font-size: var(--h2-font-size);
+}
+
+#write h3 {
+    font-family: var(--heading-Latin-font), var(--h3-Chinese-font), serif;
+    font-size: var(--h3-font-size);
+    line-height: var(--h3-font-size);
+}
+
+#write h4 {
+    font-family: var(--heading-Latin-font), var(--h4-Chinese-font), serif;
+    font-size: var(--h4-font-size);
+    line-height: var(--h4-font-size);
+}
+
+#write h5 {
+    font-family: var(--heading-Latin-font), var(--h5-Chinese-font), serif;
+    font-size: var(--h5-font-size);
+    line-height: var(--h5-font-size);
+}
+
+#write h6 {
+    font-family: var(--heading-Latin-font), var(--h6-Chinese-font), serif;
+    font-size: var(--h6-font-size);
+    line-height: var(--h5-font-size);
+    /* 没有写错，为了避免行距太小才这么写 */
+}
+
+
+.footnotes {
+    /* 参考文献（脚注）块 */
+    font-size: 0.95em;
+}
+
+.footnotes-area .footnote-line {
+    color: var(--text-color);
+}
+
+.footnotes-area hr {
+    border: 0;
+    color: var(--text-color);
+}
+
+/* == 引言 == */
+
+/* 一个>的引言仅为两字符缩进，使用>>的引言为传统引言样式，具有左竖线、左缩进 */
+blockquote {
+    font-style: normal;
+    font-family: var(--quote-font), var(--base-Latin-font), var(--base-Chinese-font), -apple-system, serif;
+    font-size: var(--quote-font-size);
+
+    border-left: 4px solid #b3b3b3;
+    padding: 0 15px;
+    color: #777777;
+}
+
+/* blockquote p:first-child {
+    padding-top: 1ch;
+  }
+
+  blockquote p:last-child {
+    padding-bottom: 1ch;
+  } */
+
+blockquote blockquote {
+    border-left: 4px solid #dfe2e5;
+    /* padding-left: calc(2ch - 4px); */
+    padding-right: 0;
+    margin-left: -4px;
+    border-radius: 0;
+}
+
+
+hr {
+    border-top: solid 1px var(--text-color);
+    margin-top: 1.8em;
+    margin-bottom: 1.8em;
+}

--- a/novel-tex/basic/basic-code-academic.css
+++ b/novel-tex/basic/basic-code-academic.css
@@ -1,0 +1,168 @@
+:root {
+    --code-font: "Consolas", var(--base-Chinese-font);
+    --code-font-size: 0.95em;
+    --li-code-bg-color: var(--bg-color);
+    --li-code-radius: 0.3em;
+    --li-code-padding: 0.2em;
+    --code-inline-font-size: 0.95em;
+    --code-bg-color: var(--bg-color);
+    --code-border-color: var(--border-color);
+}
+
+code{
+    border: 1px solid #e7eaed;
+    background-color: #f8f8f8;
+    border-radius: 3px;
+    padding: 0;
+    padding: 2px 4px 0px 4px;
+    font-size: 0.9em;
+  }
+
+
+
+.md-fences {
+    font-size: var(--code-font-size);
+    border: 1px solid var(--code-border-color);
+    padding: 10px;
+    border-radius: 0px;
+}
+
+.md-fences,
+.CodeMirror pre {
+    font-size: var(--code-font-size);
+    background: var(--code-bg-color);
+}
+
+code {
+    font-family: var(--code-font), var(--ui-font), monospace;
+    font-size: var(--base-font-size);
+}
+
+h1 code,
+h2 code,
+h3 code,
+h4 code,
+h5 code,
+h6 code,
+p code,
+li code {
+    color: var(--code-font-color);
+    background-color: var(--li-code-bg-color);
+    box-shadow: 0 0 1px 1px var(--bg-color-shader);
+    font-family: var(--code-font);
+    font-size: var(--code-inline-font-size);
+    box-sizing: border-box;
+    margin: 0 0 0 0;
+    padding: var(--li-code-padding);
+    border-radius: var(--li-code-radius);
+}
+
+
+.CodeMirror-wrap {
+    padding: 10px;
+    font-size: var(--code-font-size);
+  }
+
+.CodeMirror-code pre {
+    font-family: var(--code-font), var(--ui-font), monospace;
+}
+
+/* 改变光标的颜色，在黑暗背景下能显示*/
+.CodeMirror div.CodeMirror-cursor {
+    border-left: 1px solid var(--text-color);
+    z-index: 3;
+}
+
+.cm-s-inner .CodeMirror-guttermarker,
+.cm-s-inner .CodeMirror-guttermarker-subtle,
+.cm-s-inner .CodeMirror-linenumber {
+    color: var(--code-linenumber-color);
+}
+
+.cm-s-inner .CodeMirror-cursor {
+    border-left: 1px solid #f8f8f0;
+}
+
+.cm-s-inner div.CodeMirror-selected {
+    background: var(--select-text-bg-color);
+}
+
+.cm-s-inner.CodeMirror-focused div.CodeMirror-selected {
+    background: rgb(255, 255, 255);
+}
+
+/* 关键字 */
+.cm-s-inner .cm-keyword {
+    color: var(--code-keyword);
+}
+
+/* 操作符 */
+.cm-s-inner .cm-operator {
+    color: var(--code-operator);
+}
+
+.cm-s-inner .cm-variable {
+    color: var(--code-variable);
+}
+
+.cm-s-inner .cm-variable-2 {
+    color: var(--code-variable-2);
+}
+
+.cm-s-inner .cm-variable-3 {
+    color: var(--code-variable-3);
+}
+
+.cm-s-inner .cm-builtin {
+    color: var(--code-builtin);
+}
+
+.cm-s-inner .cm-atom {
+    color: var(--code-atom);
+}
+
+.cm-s-inner .cm-number {
+    color: var(--code-atom);
+}
+
+.cm-s-inner .cm-def {
+    color: var(--code-def);
+}
+
+.cm-s-inner .cm-string {
+    color: var(--code-string);
+}
+
+.cm-s-inner .cm-string-2 {
+    color: var(--code-string-2);
+}
+
+.cm-s-inner .cm-comment {
+    color: var(--code-comment);
+}
+
+
+.cm-s-inner .cm-tag {
+    color: var(--code-tag);
+}
+
+.cm-s-inner .cm-meta {
+    color: var(--code-meta);
+}
+
+.cm-s-inner .cm-attribute {
+    color: var(--code-attribute);
+}
+
+.cm-s-inner .cm-property {
+    color: var(--code-property);
+}
+
+.cm-s-inner .cm-qualifier {
+    color: var(--code-qualifier);
+}
+
+.cm-s-inner .cm-error {
+    color: var(--code-error);
+    background-color: var(--code-error-bg);
+}

--- a/novel-tex/light/basic-light-config-academic.css
+++ b/novel-tex/light/basic-light-config-academic.css
@@ -1,0 +1,15 @@
+@import "../basic/base-config-academic.css";
+
+:root {
+  --text-color: black;
+  --link-color: #7e8b92;
+
+  --primary-btn-text-color: black;
+  --bg-color: white;
+  --border-color: black;
+
+  --select-text-bg-color: rgb(218, 227, 234);
+  --select-text-font-color: var(--text-color);
+
+  --li-code-bg-color: rgb(238, 238, 238);
+}

--- a/novel-tex/light/code-light-academic.css
+++ b/novel-tex/light/code-light-academic.css
@@ -1,0 +1,28 @@
+@import "../basic/basic-code-academic.css";
+:root {
+    --code-linenumber-color: grey;
+    --code-keyword: #0055ff;
+    --code-operator: #000000;
+    --code-variable: #0000CC;   /*变量*/
+    --code-variable-2: #9900CC;
+    --code-variable-3: #9900CC; /*int*/
+    --code-builtin: #DECB6B;
+    --code-atom: #F77669;
+    --code-number: #F77669;
+    --code-def: #0055ff;
+    --code-string: #336633;
+    --code-string-2: #80CBC4;
+    --code-comment: #b35000;
+    --code-tag: #CC33CC;
+    --code-meta: #CC00CC;
+    --code-attribute: #FFCB6B;
+    --code-property: #80CBAE;
+    --code-qualifier: #DECB6B;
+    --code-error: rgb(255, 255, 255);
+    --code-error-bg: red;
+
+    --title-text-color: black;
+    --text-color: black;
+
+    --mermaid-theme: neutral;
+}


### PR DESCRIPTION
Signed-off-by: [RicardoLee.it@outlook.com](mailto:RicardoLee.it@outlook.com)

## Pre-Checklist

Note: please complete ALL items in the following checklist.

- [ ] l have read through the CONTRIBUTING.md documentation.
- [ ] My code has the necessary comments and documentation (if needed).
- [ ] l have added relevant tests.

## Description

- Reorganize `novel-tex`.
- Single config support implemented.
- All docs & css updated.

### Details

1. Implemented the `academic-tex-l` theme to enhance the scholarly tone of the document.
2. Adjusted the color and font size of the `code` to closely mimic the theme colors of IDEs like VS Code and GitHub.
3. Optimized the page margins for increased visual comfort during work sessions.
4. Updated the margins for printed exports to better conform to academic paper formatting standards.
5. Extended the trailing whitespace at the end of text to center the content on the screen, facilitating easier work and reading.
6. Fixed an issue where the bold formatting of the `strong` tag would disappear upon exporting to PDF, ensuring consistent font weight.
7.  modified the `quote` color and format to align with the preferences of GitHub users.

## Related link

[[修改了代码、加粗、引言、页面格式 · soryu-ryouji/novel-tex-theme@1109e05 (github.com)](https://github.com/soryu-ryouji/novel-tex-theme/commit/1109e055fb2822c9e41e563547f7975ec3b6f268)](https://github.com/soryu-ryouji/novel-tex-theme/commit/1109e055fb2822c9e41e563547f7975ec3b6f268)

[[feat：新增academic-tex-l · soryu-ryouji/novel-tex-theme@0e9d4d2 (github.com)](https://github.com/soryu-ryouji/novel-tex-theme/commit/0e9d4d21a58ed3813c04a80a106e4413fc77773b)](https://github.com/soryu-ryouji/novel-tex-theme/commit/0e9d4d21a58ed3813c04a80a106e4413fc77773b)

## New Behavior


![image-20240818124740985](https://github.com/user-attachments/assets/dd236697-6b01-4e7d-b50e-ad9ec21c7d77)


![image-20240818124756768](https://github.com/user-attachments/assets/f9ba1b01-51bd-4aea-9867-bdb9380528d0)