### PR TITLE
配合 Typora 图片生成功能，为 body 元素添加 margin 样式属性值

### DIFF
--- a/novel-tex/basic/basic.css
+++ b/novel-tex/basic/basic.css
@@ -7,7 +7,7 @@
 
 body {
   padding: 0 !important;
-  margin: 0 !important;
+  margin: 0 12% 0 10% !important;
 }
 
 img {


### PR DESCRIPTION
#4 的解决方案。
如果使用 Typora 当前的图片导出功能，因为当前 body 的 margin 是 0，结果会是这样的，很不好看：
![test-1](https://github.com/user-attachments/assets/bfb5cd7b-ae1c-43c4-96ba-dd3dcf3e6dbd)

参考了锤子便签的设计，我把 margin 调整成了 `margin: 0 12% 0 10%`。右边稍微宽一些 ~~我也不知道有什么设计学原理~~

Typora 图片导出默认是 640px 宽，字体大小为 24px。不过反正用户也可以自己调整，所以提供百分比的 margin 比较合适。

![test-2](https://github.com/user-attachments/assets/68c90545-c6f3-4f39-864c-66c291f118ef)

已经测试不会对编辑器产生任何影响。我猜是 body 的 margin 和外部页面边框的 margin 重叠，抵消了。