### PR TITLE
Update basic.css

### DIFF
--- a/novel-tex/basic/basic.css
+++ b/novel-tex/basic/basic.css
@@ -20,6 +20,15 @@ img {
     padding: var(--set-margin);
     border: 1px solid var(--body-border-color);
   }
+  h2 {
+    break-before: var(--page-break-before-h2);
+  }
+  h2:first-of-type {
+    break-before: avoid-page;
+  }
+  @page {
+    margin: 1.8cm 2cm 1.2cm 2cm !important; /* 页边距 */
+  }
 }
 
 pre.md-meta-block {


### PR DESCRIPTION
解决typora 1.10.5版本该主题导出页边距失效的问题。同时加上2级标题断页的设置。